### PR TITLE
Fix endpoints for formulasearch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = LaCASt
 	url = git@github.com:ag-gipp/LaCASt.git
 	branch = wikipedia
+[submodule "formula-cloud-server"]
+	path = formula-cloud-server
+	url = git@github.com:ag-gipp/formula-cloud-server.git

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Task 3 is executed via an external JS widget written by students at the HTW Berl
 
 ## Build ##
 
+### Initialize the submodules ###
+`git submodule update --init --recursive`
+
+### Do maven build ###
 Check-out this project and build it via Maven. In the `/target` directory you will 
 find the executable server instance `mathpipeline.jar`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,14 @@
 
     <groupId>com.formulasearchengine</groupId>
     <artifactId>vmext-demo</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <version>1.0</version>
+
+    <!-- sub modules -->
+    <modules>
+        <module>formula-cloud-server</module>
+        <module>LaCASt</module>
+    </modules>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/citeplag/controller/BaseXController.java
+++ b/src/main/java/org/citeplag/controller/BaseXController.java
@@ -11,11 +11,15 @@ import org.citeplag.domain.MathRequest;
 import org.citeplag.domain.MathUpdate;
 import org.citeplag.beans.BaseXGenericResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -64,24 +68,38 @@ public class BaseXController {
         return process(query, "xquery", request);
     }
 
-    /*
-    @PostMapping("/mwsquery")
-    //@RequestMapping(consumes="application/json")
-    @ApiOperation(value = "Run MWS query on BaseX")
-    public MathRequest mwsProcessing(
-            @RequestParam String query
-            ,HttpServletRequest request) {
 
+    @PostMapping("/mwsquery_old")
+    @ApiOperation(value = "Run MWS query on BaseX")
+    public MathRequest mwsProcessingOld(@RequestParam String query, HttpServletRequest request) {
         return process(query, "mws", request);
     }
-    */
+
+
+    @PostMapping("/mwsquery")
+    @ApiOperation(value = "Run MWS query on BaseX")
+    public MathRequest mwsProcessing(@RequestBody String data, HttpServletRequest request) {
+
+        String query = null;
+        try {
+              String result = java.net.URLDecoder.decode(data, StandardCharsets.UTF_8.name());
+              JSONObject jsonObject = new JSONObject(result);
+              query = jsonObject.get("query").toString();
+        } catch (Exception e) {
+            // not going to happen - value came from JDK's own StandardCharsets
+            e.printStackTrace();
+        }
+        return process(query, "mws", request);
+    }
+
+    /*
     @PostMapping(
             value = "mwsquery",
-            consumes = {MediaType.APPLICATION_JSON_VALUE},
-            produces = {MediaType.APPLICATION_JSON_VALUE}) //tbd clarify produces
-    @ApiOperation(value = "Run MWS query on BaseX", consumes = MediaType.APPLICATION_JSON_VALUE)
+            consumes = {MediaType.ALL_VALUE},
+            produces = {MediaType.ALL_VALUE}) //tbd clarify produces
+    @ApiOperation(value = "Run MWS query on BaseX", consumes = MediaType.ALL_VALUE)
     public MathRequest mwsProcessing(@RequestBody com.fasterxml.jackson.databind.JsonNode complete_query, HttpServletRequest request){ // @RequestBody Object person) {
-
+        // Problem with accept headers from mediawiki
         Object field = complete_query.get("query");
         if(field==null){
             // TBD Return invalid data here
@@ -91,7 +109,7 @@ public class BaseXController {
         String query = complete_query.get("query").textValue();
         return  process(query, "mws", request);
     }
-
+    */
     /*
     @PostMapping(value="/mwsquery")
     public MathRequest process(@RequestParam String query, @RequestBody com.fasterxml.jackson.databind.JsonNode request) {

--- a/src/main/java/org/citeplag/controller/BaseXController.java
+++ b/src/main/java/org/citeplag/controller/BaseXController.java
@@ -11,10 +11,8 @@ import org.citeplag.domain.MathRequest;
 import org.citeplag.domain.MathUpdate;
 import org.citeplag.beans.BaseXGenericResponse;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -66,13 +64,43 @@ public class BaseXController {
         return process(query, "xquery", request);
     }
 
+    /*
     @PostMapping("/mwsquery")
+    //@RequestMapping(consumes="application/json")
     @ApiOperation(value = "Run MWS query on BaseX")
     public MathRequest mwsProcessing(
-            @RequestParam String query,
-            HttpServletRequest request) {
+            @RequestParam String query
+            ,HttpServletRequest request) {
+
         return process(query, "mws", request);
     }
+    */
+    @PostMapping(
+            value = "mwsquery",
+            consumes = {MediaType.APPLICATION_JSON_VALUE},
+            produces = {MediaType.APPLICATION_JSON_VALUE}) //tbd clarify produces
+    @ApiOperation(value = "Run MWS query on BaseX", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public MathRequest mwsProcessing(@RequestBody com.fasterxml.jackson.databind.JsonNode complete_query, HttpServletRequest request){ // @RequestBody Object person) {
+
+        Object field = complete_query.get("query");
+        if(field==null){
+            // TBD Return invalid data here
+            return  process(null, "mws", request);
+        }
+
+        String query = complete_query.get("query").textValue();
+        return  process(query, "mws", request);
+    }
+
+    /*
+    @PostMapping(value="/mwsquery")
+    public MathRequest process(@RequestParam String query, @RequestBody com.fasterxml.jackson.databind.JsonNode request) {
+        // Just a test for json
+        return process(query, "mws", null);
+
+    }
+    */
+
 
     private MathRequest process(String query, String type, HttpServletRequest request) {
         if (!startServerIfNecessary()) {


### PR DESCRIPTION
 Former endpoint didn't receive messages. ("mwsquery_old") 
Formulasearch extension sends url-decoded info which isn't parsed by spring. 
New endpoint gets the query correctly. 

Is there a more elegant solution with spring-type of annotations which does implicit parsing?